### PR TITLE
fix: signature for pairwise mapping

### DIFF
--- a/src/CoreComputing.jl
+++ b/src/CoreComputing.jl
@@ -145,7 +145,7 @@ end
 function map_pairwise_serial!(
     f::F, output, box::Box, 
     cl::CellListPair{N,T}; 
-    show_progress=show_progress
+    show_progress::Bool=false
 ) where {F,N,T}
     p = show_progress ? Progress(length(cl.ref), dt=1) : nothing
     for i in eachindex(cl.ref)
@@ -170,7 +170,7 @@ function map_pairwise_parallel!(
     cl::CellListPair{N,T};
     output_threaded=nothing,
     reduce::F2=reduce,
-    show_progress=show_progress
+    show_progress::Bool=false
 ) where {F1,F2,N,T}
     nbatches = cl.target.nbatches.map_computation
     if isnothing(output_threaded) 


### PR DESCRIPTION
Fixed signature for `map_pairwise_serial!` and `map_pairwise_parallel!` for `CellListPair` type.

Currently, the package fails for the following example:
```julia
using CellListMap

box = Box([100,100,100],20)
b1 = [[100,100,100] .* rand(3) for _ in 1:10]
b2 = [[100,100,100] .* rand(3) for _ in 1:10]
cl = CellList(b1, b2, box)

CellListMap.map_pairwise_serial!((x,y,i,j,d2,output)->output, nothing, box, cl)
```
because keyword `show_progress` is by default `show_progress` which is not defined elsewhere.