### PR TITLE
Merge cell lists in parallel. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Parallel calculations are the default if more than one thread is available. Use 
 
 The goal here is to provide a good implementation of cell lists. We compare it with the implementation of the nice cython/python [halotools](https://github.com/astropy/halotools) package, in the computation of an histogram of mean pairwise velocities. 
 
-<img src=https://github.com/lmiq/PairVelocities/blob/main/data/cd_v0.5.3.png>
+<img src=https://github.com/lmiq/PairVelocities/blob/main/data/cd_v0.8.27-DEV.png>
 
-<img src=https://github.com/lmiq/PairVelocities/blob/main/data/cv_v0.5.3.png>
+<img src=https://github.com/lmiq/PairVelocities/blob/main/data/cv_v0.8.27-DEV.png>
 
-The full test is available [at this](https://github.com/lmiq/PairVelocities) repository. And we kindly thank [Carolina Cuesta](https://github.com/florpi) for providing the example. These benchmarks were run on an Intel i7 8th gen laptop, with 4 cores (8 threads). 
+The full test is available [at this](https://github.com/lmiq/PairVelocities) repository. And we kindly thank [Carolina Cuesta](https://github.com/florpi) for providing the example. These benchmarks were run on an Intel(R) Core(TM) i7-12700, using 8 CPUs. 
 
 ## Citation
 

--- a/src/CellListMap.jl
+++ b/src/CellListMap.jl
@@ -8,6 +8,7 @@ using StaticArrays: SVector, SMatrix, @SVector, @SMatrix, MVector, MMatrix
 using Setfield: @set!
 using LinearAlgebra: cross, diagm, I
 using Base.Threads: nthreads, @spawn 
+using Base: @lock # not exported in 1.6
 
 export Box
 export CellList, UpdateCellList!

--- a/src/CellLists.jl
+++ b/src/CellLists.jl
@@ -351,7 +351,7 @@ julia> aux = CellListMap.AuxThreaded(cl)
 CellListMap.AuxThreaded{3, Float64}
  Auxiliary arrays for nthreads = 8
 
-julia> cl = UpdateCellList!(x,box,cl,aux)
+julia> UpdateCellList!(x,box,cl,aux)
 CellList{3, Float64}
   100000 real particles.
   31190 cells with real particles.
@@ -432,7 +432,7 @@ julia> aux = CellListMap.AuxThreaded(cl)
 CellListMap.AuxThreaded{3, Float64}
  Auxiliary arrays for nthreads = 8
 
-julia> cl = UpdateCellList!(x,box,cl,aux)
+julia> UpdateCellList!(x,box,cl,aux)
 CellList{3, Float64}
   100000 real particles.
   31190 cells with real particles.
@@ -483,7 +483,7 @@ function CellList(
         n_real_particles=length(x),
         number_of_cells=prod(box.nc),
     )
-    cl = set_number_of_batches!(cl, nbatches, parallel=parallel)
+    set_number_of_batches!(cl, nbatches, parallel=parallel)
     return UpdateCellList!(x, box, cl, parallel=parallel)
 end
 
@@ -631,7 +631,7 @@ julia> box = Box([260,260,260],10);
 
 julia> x = [ 260*rand(SVector{3,Float64}) for i in 1:1000 ];
 
-julia> cl = UpdateCellList!(x,box,cl); # update lists
+julia> UpdateCellList!(x,box,cl); # update lists
 
 ```
 
@@ -754,11 +754,11 @@ function UpdateCellList!(
     # Add particles to cell list
     nbatches = cl.nbatches.build_cell_lists
     if !parallel || nbatches == 1
-        cl = reset!(cl, box, length(x))
+        reset!(cl, box, length(x))
         add_particles!(x, box, 0, cl)
     else
         # Reset cell list
-        cl = reset!(cl, box, 0)
+        reset!(cl, box, 0)
         # Update the aux.idxs ranges, for if the number of particles changed
         set_idxs!(aux.idxs, length(x), nbatches)
         merge_lock = ReentrantLock()
@@ -834,8 +834,8 @@ function add_particles!(x, box, ishift, cl::CellList{N,T}) where {N,T}
         # This converts the coordinates to static arrays, if necessary
         p = SVector{N,T}(ntuple(i -> xp[i], N))
         p = box.rotation * wrap_to_first(p, box.input_unit_cell.matrix)
-        cl = add_particle_to_celllist!(ishift + ip, p, box, cl) # add real particle
-        cl = replicate_particle!(ishift + ip, p, box, cl) # add virtual particles to border cells
+        add_particle_to_celllist!(ishift + ip, p, box, cl) # add real particle
+        replicate_particle!(ishift + ip, p, box, cl) # add virtual particles to border cells
     end
     return cl
 end
@@ -1087,7 +1087,7 @@ julia> y = [ 250*rand(SVector{3,Float64}) for i in 1:10000 ];
 
 julia> cl = CellList(x,y,box);
 
-julia> cl = UpdateCellList!(x,y,box,cl); # update lists
+julia> UpdateCellList!(x,y,box,cl); # update lists
 
 ```
 
@@ -1172,7 +1172,7 @@ julia> x = [ 250*rand(3) for i in 1:50_000 ];
 
 julia> y = [ 250*rand(3) for i in 1:10_000 ];
 
-julia> cl = UpdateCellList!(x,y,box,cl,aux)
+julia> UpdateCellList!(x,y,box,cl,aux)
 CellList{3, Float64}
   10000 real particles.
   7358 cells with real particles.

--- a/src/CellLists.jl
+++ b/src/CellLists.jl
@@ -520,18 +520,11 @@ function reset!(cl::CellList{N,T}, box, n_real_particles) where {N,T}
     end
     @. cl.cell_indices = 0
     @. cl.cell_indices_real = 0
-    cl = CellList{N,T}(
-        n_real_particles=n_real_particles,
-        n_particles=0,
-        number_of_cells=new_number_of_cells,
-        n_cells_with_real_particles=0,
-        n_cells_with_particles=0,
-        cell_indices=cl.cell_indices,
-        cell_indices_real=cl.cell_indices_real,
-        cells=cl.cells,
-        nbatches=cl.nbatches,
-        projected_particles=cl.projected_particles
-    )
+    cl.n_real_particles = n_real_particles
+    cl.n_particles = 0
+    cl.number_of_cells = new_number_of_cells
+    cl.n_cells_with_real_particles = 0
+    cl.n_cells_with_particles = 0
     return cl
 end
 
@@ -760,7 +753,7 @@ function UpdateCellList!(
     nbatches = cl.nbatches.build_cell_lists
     if !parallel || nbatches == 1
         cl = reset!(cl, box, length(x))
-        cl = add_particles!(x, box, 0, cl)
+        add_particles!(x, box, 0, cl)
     else
         # Reset cell list
         cl = reset!(cl, box, 0)

--- a/src/CoreComputing.jl
+++ b/src/CoreComputing.jl
@@ -252,7 +252,6 @@ function _current_cell_interactions!(box::Box{TriclinicCell}, f::F, cell, output
         pᵢ.real || continue
         for j in 1:cell.n_particles
             @inbounds pⱼ = cell.particles[j]
-            #(pᵢ.index >= pⱼ.index) && (pᵢ.real || pⱼ.real) && continue
             (pᵢ.index >= pⱼ.index) && continue
             xpⱼ = pⱼ.coordinates
             d2 = norm_sqr(xpᵢ - xpⱼ)

--- a/src/CoreComputing.jl
+++ b/src/CoreComputing.jl
@@ -203,39 +203,36 @@ inner_loop!(f::F, box::Box{<:OrthorhombicCellType}, cellᵢ, cl::CellList, outpu
     inner_loop!(f, neighbor_cells_forward, box, cellᵢ, cl, output, ibatch)
 inner_loop!(f::F, box::Box{<:TriclinicCell}, cellᵢ, cl::CellList, output, ibatch) where {F<:Function} =
     inner_loop!(f, neighbor_cells, box, cellᵢ, cl, output, ibatch)
-#
-# The criteria form skipping computations is different then in Orthorhombic or Triclinic boxes
-skip_particle_i(pᵢ, ::Box{<:OrthorhombicCellType}) = false
-skip_pair(pᵢ, pⱼ, ::Box{<:OrthorhombicCellType}) = false
-skip_particle_i(pᵢ, ::Box{<:TriclinicCell}) = !pᵢ.real
-skip_pair(pᵢ, pⱼ, ::Box{<:TriclinicCell}) = pᵢ.index > pⱼ.index
-
-# We are not doing the above procedure, which allows for a more efficient
-# mapping in orthorhombic cells beacause of issue 84 (https://github.com/m3g/CellListMap.jl/issues/84)
-#inner_loop!(f::F, box::Box, cellᵢ, cl::CellList, output, ibatch) where {F<:Function} =
-#    inner_loop!(f, neighbor_cells, box, cellᵢ, cl, output, ibatch)
-#skip_particle_i(pᵢ, ::Box) = !pᵢ.real
-#skip_pair(pᵢ, pⱼ, ::Box) = pᵢ.index >= pⱼ.index
 
 function inner_loop!(
-    f::Function,
-    _neighbor_cells::F, # depends on cell type
-    box::Box,
+    f::F,
+    _neighbor_cells::NC, # depends on cell type
+    box,
     cellᵢ,
     cl::CellList{N,T},
     output,
     ibatch
-) where {F<:Function,N,T}
+) where {F<:Function,NC<:Function,N,T}
     @unpack cutoff_sqr, inv_rotation, nc = box
+    output = _current_cell_interactions!(box, f, cellᵢ, output)
+    for jcell in _neighbor_cells(box)
+        jc_linear = cell_linear_index(nc, cellᵢ.cartesian_index + jcell)
+        if cl.cell_indices[jc_linear] != 0
+            cellⱼ = cl.cells[cl.cell_indices[jc_linear]]
+            output = _vicinal_cell_interactions!(f, box, cellᵢ, cellⱼ, cl, output, ibatch)
+        end
+    end
+    return output
+end
 
-    # loop over list of non-repeated particles of cell ic
-    for i in 1:cellᵢ.n_particles-1
-        @inbounds pᵢ = cellᵢ.particles[i]
-        skip_particle_i(pᵢ, box) && continue
+function _current_cell_interactions!(box::Box{<:OrthorhombicCellType}, f::F, cell, output) where {F<:Function}
+    @unpack cutoff_sqr, inv_rotation = box
+    # loop over list of non-repeated particles of cell ic. All particles are real
+    for i in 1:cell.n_particles-1
+        @inbounds pᵢ = cell.particles[i]
         xpᵢ = pᵢ.coordinates
-        for j in i+1:cellᵢ.n_particles
-            @inbounds pⱼ = cellᵢ.particles[j]
-            skip_pair(pᵢ, pⱼ, box) && continue
+        for j in i+1:cell.n_particles
+            @inbounds pⱼ = cell.particles[j]
             xpⱼ = pⱼ.coordinates
             d2 = norm_sqr(xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
@@ -243,46 +240,61 @@ function inner_loop!(
             end
         end
     end
-
-    for jcell in _neighbor_cells(box)
-        jc_linear = cell_linear_index(nc, cellᵢ.cartesian_index + jcell)
-        if cl.cell_indices[jc_linear] != 0
-            cellⱼ = cl.cells[cl.cell_indices[jc_linear]]
-            output = cell_output!(f, box, cellᵢ, cellⱼ, cl, output, ibatch)
-        end
-    end
-
     return output
 end
 
-function cell_output!(f, box::Box, cellᵢ, cellⱼ, cl::CellList{N,T}, output, ibatch) where {N,T}
-    @unpack cutoff, cutoff_sqr, inv_rotation = box
+function _current_cell_interactions!(box::Box{TriclinicCell}, f::F, cell, output) where {F<:Function}
+    @unpack cutoff_sqr, inv_rotation = box
+    # loop over all pairs, skip when i >= j, skip if neither particle is real
+    for i in 1:cell.n_particles
+        @inbounds pᵢ = cell.particles[i]
+        xpᵢ = pᵢ.coordinates
+        pᵢ.real || continue
+        for j in 1:cell.n_particles
+            @inbounds pⱼ = cell.particles[j]
+            #(pᵢ.index >= pⱼ.index) && (pᵢ.real || pⱼ.real) && continue
+            (pᵢ.index >= pⱼ.index) && continue
+            xpⱼ = pⱼ.coordinates
+            d2 = norm_sqr(xpᵢ - xpⱼ)
+            if d2 <= cutoff_sqr
+                output = f(inv_rotation * xpᵢ, inv_rotation * xpⱼ, pᵢ.index, pⱼ.index, d2, output)
+            end
+        end
+    end
+    return output
+end
 
+#
+# Compute interactions between vicinal cells
+#
+function _vicinal_cell_interactions!(f::F, box::Box, cellᵢ, cellⱼ, cl::CellList{N,T}, output, ibatch) where {F<:Function,N,T}
     # project particles in vector connecting cell centers
     Δc = cellⱼ.center - cellᵢ.center
     Δc_norm = norm(Δc)
     Δc = Δc / Δc_norm
     pp = project_particles!(cl.projected_particles[ibatch], cellⱼ, cellᵢ, Δc, Δc_norm, box)
-    if length(pp) == 0
-        return output
+    if length(pp) > 0
+        output = _vinicial_cells!(f, box, cellᵢ, pp, Δc, output)
     end
+    return output
+end
 
+#
+# The criteria form skipping computations is different then in Orthorhombic or Triclinic boxes
+#
+function _vinicial_cells!(f::F, box::Box{<:OrthorhombicCellType}, cellᵢ, pp, Δc, output) where {F<:Function}
+    @unpack cutoff, cutoff_sqr, inv_rotation = box
     # Loop over particles of cell icell
     for i in 1:cellᵢ.n_particles
         @inbounds pᵢ = cellᵢ.particles[i]
-        skip_particle_i(pᵢ, box) && continue
-
         # project particle in vector connecting cell centers
         xpᵢ = pᵢ.coordinates
         xproj = dot(xpᵢ - cellᵢ.center, Δc)
-
         # Partition pp array according to the current projections
         n = partition!(el -> abs(el.xproj - xproj) <= cutoff, pp)
-
         # Compute the interactions 
         for j in 1:n
             @inbounds pⱼ = pp[j]
-            skip_pair(pᵢ, pⱼ, box) && continue
             xpⱼ = pⱼ.coordinates
             d2 = norm_sqr(xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
@@ -290,7 +302,31 @@ function cell_output!(f, box::Box, cellᵢ, cellⱼ, cl::CellList{N,T}, output, 
             end
         end
     end
+    return output
+end
 
+function _vinicial_cells!(f::F, box::Box{<:TriclinicCell}, cellᵢ, pp, Δc, output) where {F<:Function}
+    @unpack cutoff, cutoff_sqr, inv_rotation = box
+    # Loop over particles of cell icell
+    for i in 1:cellᵢ.n_particles
+        @inbounds pᵢ = cellᵢ.particles[i]
+        # project particle in vector connecting cell centers
+        xpᵢ = pᵢ.coordinates
+        xproj = dot(xpᵢ - cellᵢ.center, Δc)
+        # Partition pp array according to the current projections
+        n = partition!(el -> abs(el.xproj - xproj) <= cutoff, pp)
+        # Compute the interactions 
+        pᵢ.real || continue
+        for j in 1:n
+            @inbounds pⱼ = pp[j]
+            pᵢ.index >= pⱼ.index && continue
+            xpⱼ = pⱼ.coordinates
+            d2 = norm_sqr(xpᵢ - xpⱼ)
+            if d2 <= cutoff_sqr
+                output = f(inv_rotation * xpᵢ, inv_rotation * xpⱼ, pᵢ.index, pⱼ.index, d2, output)
+            end
+        end
+    end
     return output
 end
 


### PR DESCRIPTION
With this PR the cell lists are merged in parallel when constructed in parallel. The performance improvements, if any, are small. But the scaling may be improved when using larger numbers of batches for cell list construction, in systems with many CPUs.

The code was somewhat simplified by making `CellList` a mutable struct, which was required to avoid the allocations caused by the closure capture.

We also split completely the inner loops of orthorrombic and tricilinic cells, which will probably make the code maintenance easier. This was also required because with the lists being merged in any order, the triclinic merging was broken because of the pair skipping rules.


