### PR TITLE
improve error message for undefined `copy_output`

### DIFF
--- a/src/ParticleSystem.jl
+++ b/src/ParticleSystem.jl
@@ -454,7 +454,7 @@ function copy_output(x)
         CellListMap.copy_output(x::$(typeof(x)))
 
         with an appropriate way to copy the required output variable. Many times just
-        defining `output_copy(x::$(typeof(x))) = deepcopy(x)` is ok. 
+        defining `CellListMap.copy_output(x::$(typeof(x))) = deepcopy(x)` is ok. 
     """))
 end
 copy_output(x::T) where {T<:SupportedTypes} = copy(x)


### PR DESCRIPTION
the error message spuriously told the user to define `output_copy` instead of `copy_output`.