### PR TITLE
Internal vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Version 0.10.0-DEV
 - ![INFO][badge-info] Add performance test.
 - ![INFO][badge-info] Update examples.
 - ![INFO][badge-info] Default name for output in ParticleSystem is `default_output_name`, but it can be accessed though `sys.output`, as before.
+- ![INFO][badge-info] Internal fields of ParticleSystems are not part of `PrivateParticleSystemData` and are accessed through internal getter functions, or through `sys.private.field`. 
 - ![BUGFIX][badge-bugfix] Fix cross-computation (`pairwise!(f, x, sys)`) with `NonPeriodicCell` failing to find pairs when particle coordinates span negative values or large coordinate ranges / do not modify input coordinates in `NonPeriodicCell`. This bug was never released, it was created and fixed in the development version.
 - ![BUGFIX][badge-bugfix] If the number of particles is reduced by updating and becomes smaller than nbatches, there was a crash. Fixed. Also fixed automatic updating of nbatches when first set of positions change (bug never released).
 - ![BUGFIX][badge-bugfix] Fix `nbatches` not being updated for the `:map` phase of `CellListPair` systems when the particle count changes (bug never released).

--- a/src/API/AbstractParticleSystem.jl
+++ b/src/API/AbstractParticleSystem.jl
@@ -11,6 +11,13 @@ Use the `ParticleSystem` constructor and interface for anything else than dispat
 """
 abstract type AbstractParticleSystem{OutputName} end
 
+mutable struct PrivateParticleSystemData{B,C,O,A}
+    box::B
+    cell_list::C
+    output_threaded::Vector{O}
+    aux::A
+end
+
 """
 
     ParticleSystem1
@@ -22,16 +29,14 @@ pairs of particles of the set). Can be used to control dispatch.
 Use the `ParticleSystem` constructor and interface for anything else than dispatch.
 
 """
-mutable struct ParticleSystem1{OutputName, V, O, B, C, A, VC} <: AbstractParticleSystem{OutputName}
+mutable struct ParticleSystem1{OutputName, V, O, VC, P<:PrivateParticleSystemData} <: AbstractParticleSystem{OutputName}
     xpositions::V
     output::O
-    _box::B
-    _cell_list::C
-    _output_threaded::Vector{O}
-    _aux::A
     parallel::Bool
     validate_coordinates::VC
+    private::P
 end
+
 
 """
 
@@ -45,16 +50,12 @@ Can be used to control dispatch.
 Use the `ParticleSystem` constructor and interface for anything else than dispatch.
 
 """
-mutable struct ParticleSystem2{OutputName, V, O, B, C, A, VC} <: AbstractParticleSystem{OutputName}
+mutable struct ParticleSystem2{OutputName, V, O, VC, P<:PrivateParticleSystemData} <: AbstractParticleSystem{OutputName}
     xpositions::V
     ypositions::V
     output::O
-    _box::B
-    _cell_list::C
-    _output_threaded::Vector{O}
-    _aux::A
     parallel::Bool
     validate_coordinates::VC
+    private::P
 end
-ParticleSystem2{OutputName}(vx::V, vy::V, o::O, b::B, c::C, vo::Vector{O}, a::A, p::Bool, vc::VC) where {OutputName, V, O, B, C, A, VC} =
-    ParticleSystem2{OutputName, V, O, B, C, A, VC}(vx, vy, o, b, c, vo, a, p, vc)
+

--- a/src/API/ParticleSystem.jl
+++ b/src/API/ParticleSystem.jl
@@ -206,11 +206,11 @@ getproperty(sys::AbstractParticleSystem, s::Symbol) = getproperty(sys, Val(s))
 getproperty(sys::AbstractParticleSystem, ::Val{S}) where {S} = getfield(sys, S)
 # public properties
 getproperty(sys::AbstractParticleSystem, ::Val{:positions}) = getfield(sys, :xpositions)
-getproperty(sys::AbstractParticleSystem, ::Val{:unitcell}) = getfield(getfield(getfield(sys, :_box), :input_unit_cell), :matrix)
-getproperty(sys::AbstractParticleSystem, ::Val{:cutoff}) = getfield(getfield(sys, :_box), :cutoff)
+getproperty(sys::AbstractParticleSystem, ::Val{:unitcell}) = unitcell(sys)
+getproperty(sys::AbstractParticleSystem, ::Val{:cutoff}) = cutoff(sys)
 getproperty(sys::AbstractParticleSystem{OutputName}, ::Val{OutputName}) where {OutputName} = getfield(sys, :output)
 propertynames(::AbstractParticleSystem{OutputName}) where {OutputName} =
-    (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, OutputName)
+    (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, :private, OutputName)
 
 import Base: setproperty!
 # public properties
@@ -218,9 +218,4 @@ setproperty!(sys::AbstractParticleSystem, s::Symbol, x) = setproperty!(sys, Val(
 setproperty!(sys::AbstractParticleSystem, ::Val{:unitcell}, x) = _update_unitcell!(sys, x)
 setproperty!(sys::AbstractParticleSystem, ::Val{:cutoff}, x) = _update_cutoff!(sys, x)
 setproperty!(sys::AbstractParticleSystem, ::Val{:parallel}, x) = setfield!(sys, :parallel, x)
-# private properties
-setproperty!(sys::AbstractParticleSystem, ::Val{:_box}, x) = setfield!(sys, :_box, x)
-setproperty!(sys::AbstractParticleSystem, ::Val{:_cell_list}, x) = setfield!(sys, :_cell_list, x)
 setproperty!(sys::AbstractParticleSystem, ::Val{:output}, x) = setfield!(sys, :output, x)
-setproperty!(sys::AbstractParticleSystem, ::Val{:_aux}, x) = setfield!(sys, :_aux, x)
-setproperty!(sys::AbstractParticleSystem, ::Val{:_output_threaded}, x) = setfield!(sys, :_output_threaded, x)

--- a/src/API/get_computing_box.jl
+++ b/src/API/get_computing_box.jl
@@ -8,4 +8,4 @@ Retrieves the computing box of the system. The computing box is large enough to
 contain all coordinates of the particles, plus the cutoff.
 
 """
-get_computing_box(sys::AbstractParticleSystem) = sys._box.computing_box
+get_computing_box(sys::AbstractParticleSystem) = box(sys).computing_box

--- a/src/API/neighborlist.jl
+++ b/src/API/neighborlist.jl
@@ -146,8 +146,8 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", system::InPlaceNeighborList)
     _print(io, "InPlaceNeighborList with types: \n")
-    _print(io, typeof(system.sys._cell_list), "\n")
-    _print(io, typeof(system.sys._box), "\n")
+    _print(io, typeof(celllist(system.sys)), "\n")
+    _print(io, typeof(box(system.sys)), "\n")
     return _print(io, "Current list buffer length: $(length(system.sys.nb.list))")
 end
 
@@ -192,13 +192,13 @@ julia> @time neighborlist!(system; parallel=false)
 """
 function neighborlist!(system::InPlaceNeighborList)
     (; sys) = system
-    sys.output = _reset_all_output!(sys.output, sys._output_threaded; reset = true)
+    sys.output = _reset_all_output!(sys.output, output_threaded(sys); reset = true)
     UpdateParticleSystem!(sys)
     _sizehint_neighbor_lists!(sys)
     sys.output = _pairwise!(
         push_pair!,
-        sys.output, sys._box, sys._cell_list;
-        output_threaded = sys._output_threaded,
+        sys.output, box(sys), celllist(sys);
+        output_threaded = output_threaded(sys),
         parallel = sys.parallel,
         show_progress = system.show_progress,
     )

--- a/src/API/pairwise.jl
+++ b/src/API/pairwise.jl
@@ -51,11 +51,11 @@ function pairwise!(
         show_progress::Bool = false,
         reset::Bool = true,
     ) where {F <: Function}
-    sys.output = _reset_all_output!(sys.output, sys._output_threaded; reset)
+    sys.output = _reset_all_output!(sys.output, output_threaded(sys); reset)
     UpdateParticleSystem!(sys)
     sys.output = _pairwise!(
-        f, sys.output, sys._box, sys._cell_list;
-        output_threaded = sys._output_threaded,
+        f, sys.output, box(sys), celllist(sys);
+        output_threaded = output_threaded(sys),
         parallel = sys.parallel,
         show_progress = show_progress
     )

--- a/src/API/updating.jl
+++ b/src/API/updating.jl
@@ -17,8 +17,9 @@ must be implemented by the user.
 """
 function resize_output!(sys::AbstractParticleSystem, n::Int)
     resize!(sys.output, n)
-    for i in eachindex(sys._output_threaded)
-        resize!(sys._output_threaded[i], n)
+    _output_threaded = output_threaded(sys)
+    for i in eachindex(_output_threaded)
+        resize!(_output_threaded[i], n)
     end
     return sys
 end

--- a/src/API/updating.jl
+++ b/src/API/updating.jl
@@ -38,12 +38,12 @@ function _update_unitcell!(sys, unitcell)
             )
         )
     end
-    sys._box = update_box(sys._box; unitcell)
-    _update_sys_box!(sys)
+    _update!(sys, update_box(box(sys); unitcell))
+    _updated_sys_coordinates!(sys)
     return sys
 end
-_update_sys_box!(sys::ParticleSystem1) = sys.xpositions.updated[] = true
-function _update_sys_box!(sys::ParticleSystem2)
+_updated_sys_coordinates!(sys::ParticleSystem1) = sys.xpositions.updated[] = true
+function _updated_sys_coordinates!(sys::ParticleSystem2)
     sys.xpositions.updated[] = true
     sys.ypositions.updated[] = true
 end
@@ -51,9 +51,9 @@ end
 function _update_cutoff!(sys::ParticleSystem1, cutoff)
     _cutoff = isnothing(cutoff) ? sys.cutoff : cutoff
     if unitcelltype(sys) == NonPeriodicCell
-        sys._box = Box(limits(sys.xpositions), _cutoff)
+        _update!(sys, Box(limits(sys.xpositions), _cutoff))
     else
-        sys._box = update_box(sys._box; cutoff=_cutoff)
+        _update!(sys, update_box(box(sys); cutoff=_cutoff))
     end
     sys.xpositions.updated[] = true
     return sys
@@ -61,9 +61,9 @@ end
 function _update_cutoff!(sys::ParticleSystem2, cutoff)
     _cutoff = isnothing(cutoff) ? sys.cutoff : cutoff
     if unitcelltype(sys) == NonPeriodicCell
-        sys._box = Box(limits(sys.xpositions, sys.ypositions), _cutoff)
+        _update!(sys, Box(limits(sys.xpositions, sys.ypositions), _cutoff))
     else
-        sys._box = update_box(sys._box; cutoff=_cutoff)
+        _update!(sys, update_box(box(sys); cutoff=_cutoff))
     end
     sys.xpositions.updated[] = true
     sys.ypositions.updated[] = true

--- a/src/internals/ParticleSystem.jl
+++ b/src/internals/ParticleSystem.jl
@@ -1,9 +1,3 @@
-mutable struct PrivateParticleSystemData{B,C,O,A}
-    box::B
-    cell_list::C
-    output_threaded::Vector{O}
-    aux::A
-end
 
 # Types of variables that have support for multi-threading without having
 # to explicit add methods to copy_output, reset_output!, and reducer functions.
@@ -15,38 +9,38 @@ const SupportedCoordinatesTypes = Union{Nothing, AbstractVector{<:AbstractVector
 #
 # Internal getters
 #
-box(sys::AbstractParticleSystem) = sys._box
-cutoff(sys::AbstractParticleSystem) = sys._box.cutoff
-unitcell(sys::AbstractParticleSystem) = sys._box.input_unit_cell.matrix
-unitcelltype(sys::AbstractParticleSystem) = unitcelltype(sys._box)
+box(sys::AbstractParticleSystem) = sys.private.box
+cutoff(sys::AbstractParticleSystem) = sys.private.box.cutoff
+unitcell(sys::AbstractParticleSystem) = sys.private.box.input_unit_cell.matrix
+unitcelltype(sys::AbstractParticleSystem) = unitcelltype(sys.private.box)
 dim(sys::AbstractParticleSystem) = size(unitcell(sys), 1)
 output_type(sys) = typeof(sys.output)
 
-aux_threaded(sys) = sys._aux
-output_threaded(sys) = sys._output_threaded
+aux_threaded(sys) = sys.private.aux
+output_threaded(sys) = sys.private.output_threaded
 
-celllist(sys::AbstractParticleSystem) = sys._cell_list
+celllist(sys::AbstractParticleSystem) = sys.private.cell_list
 celllist(sys::ParticleSystem2, s::Symbol) = celllist(sys, Val(s))
-celllist(sys, ::Val{:ref}) = sys._cell_list.ref_list
-celllist(sys, ::Val{:target}) = sys._cell_list.target_list
+celllist(sys, ::Val{:ref}) = sys.private.cell_list.ref_list
+celllist(sys, ::Val{:target}) = sys.private.cell_list.target_list
 
 n_real_particles(sys, s::Symbol) = n_real_particles(sys, Val(s)) 
-n_real_particles(sys, ::Val{:ref}) = sys._cell_list.ref_list.n_real_particles
-n_real_particles(sys, ::Val{:target}) = sys._cell_list.target_list.n_real_particles
+n_real_particles(sys, ::Val{:ref}) = sys.private.cell_list.ref_list.n_real_particles
+n_real_particles(sys, ::Val{:target}) = sys.private.cell_list.target_list.n_real_particles
 
 updated(sys, s::Symbol) = updated(sys, Val(s))
 updated(sys, ::Val{:x}) = sys.xpositions.updated[]
 updated(sys, ::Val{:y}) = sys.ypositions.updated[]
 
-#=
-    unitcelltype(sys::AbstractParticleSystem)
+# Constructor for ParticleSystem1
+ParticleSystem1{OutputName}(vx::V, o::O, b::B, c::C, vo::AbstractVector{O}, a::A, p::Bool, vc::VC) where {OutputName, V, O, B, C, A, VC} =
+    ParticleSystem1{OutputName, V, O, VC, PrivateParticleSystemData{B, C, O, A}}(vx, o, p, vc, PrivateParticleSystemData(b, c, vo, a))
 
-Returns the type of a unitcell from the `ParticleSystem` structure.
+# Constructor for ParticleSystem2
+ParticleSystem2{OutputName}(vx::V, vy::V, o::O, b::B, c::C, vo::Vector{O}, a::A, p::Bool, vc::VC) where {OutputName, V, O, B, C, A, VC} =
+    ParticleSystem2{OutputName, V, O, VC, PrivateParticleSystemData{B, C, O, A}}(vx, vy, o, p, vc, PrivateParticleSystemData(b, c, vo, a))
 
-=#
-
-ParticleSystem1{OutputName}(v::V, o::O, b::B, c::C, vo::AbstractVector{O}, a::A, p::Bool, vc::VC) where {OutputName, V, O, B, C, A, VC} =
-    ParticleSystem1{OutputName, V, O, B, C, A, VC}(v, o, b, c, vo, a, p, vc)
+# Alias "positions" to "xpositions"
 getproperty(sys::ParticleSystem1, ::Val{:positions}) = getfield(sys, :xpositions)
 getproperty(sys::ParticleSystem2, ::Val{:positions}) = getfield(sys, :xpositions)
 
@@ -111,9 +105,9 @@ end
 #
 # Internal updaters
 #
-_update!(sys::AbstractParticleSystem, box::Box) = sys._box = box
+_update!(sys::AbstractParticleSystem, box::Box) = sys.private.box = box
 function _update!(sys::ParticleSystem1, ::Type{CellList}) 
-    n_particles_changed = length(sys.xpositions) != sys._cell_list.n_real_particles
+    n_particles_changed = length(sys.xpositions) != sys.private.cell_list.n_real_particles
     UpdateCellList!(
         sys.xpositions,
         box(sys),
@@ -124,11 +118,11 @@ function _update!(sys::ParticleSystem1, ::Type{CellList})
     )
     if n_particles_changed
         _old_nbatches = get_nbatches(sys)
-        sys._cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
+        sys.private.cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
         _new_nbatches = get_nbatches(sys)
         if _old_nbatches != _new_nbatches
-            sys._aux = _create_aux(box(sys), celllist(sys))
-            sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
+            sys.private.aux = _create_aux(box(sys), celllist(sys))
+            sys.private.output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
         end
     end
     sys.xpositions.updated[] = false
@@ -163,7 +157,7 @@ function _update!(sys::ParticleSystem2, ::Type{CellList})
     n_particles_changed = 
         (length(sys.xpositions) != n_real_particles(sys, :ref)) ||
         (length(sys.ypositions) != n_real_particles(sys, :target))
-    sys._cell_list = UpdateCellList!(
+    sys.private.cell_list = UpdateCellList!(
         sys.xpositions,
         sys.ypositions,
         box(sys),
@@ -174,11 +168,11 @@ function _update!(sys::ParticleSystem2, ::Type{CellList})
     )
     if n_particles_changed
         _old_nbatches = get_nbatches(sys)
-        sys._cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
+        sys.private.cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
         _new_nbatches = get_nbatches(sys)
         if _old_nbatches != _new_nbatches
-            sys._aux = _create_aux(box(sys), celllist(sys))
-            sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
+            sys.private.aux = _create_aux(box(sys), celllist(sys))
+            sys.private.output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
         end
     end
     sys.xpositions.updated[] = false

--- a/src/internals/ParticleSystem.jl
+++ b/src/internals/ParticleSystem.jl
@@ -1,3 +1,10 @@
+mutable struct PrivateParticleSystemData{B,C,O,A}
+    box::B
+    cell_list::C
+    output_threaded::Vector{O}
+    aux::A
+end
+
 # Types of variables that have support for multi-threading without having
 # to explicit add methods to copy_output, reset_output!, and reducer functions.
 const SupportedTypes = Union{Number, SVector, FieldVector}
@@ -5,13 +12,38 @@ const SupportedTypes = Union{Number, SVector, FieldVector}
 # Supported types for coordinates
 const SupportedCoordinatesTypes = Union{Nothing, AbstractVector{<:AbstractVector}, AbstractMatrix}
 
+#
+# Internal getters
+#
+box(sys::AbstractParticleSystem) = sys._box
+cutoff(sys::AbstractParticleSystem) = sys._box.cutoff
+unitcell(sys::AbstractParticleSystem) = sys._box.input_unit_cell.matrix
+unitcelltype(sys::AbstractParticleSystem) = unitcelltype(sys._box)
+dim(sys::AbstractParticleSystem) = size(unitcell(sys), 1)
+output_type(sys) = typeof(sys.output)
+
+aux_threaded(sys) = sys._aux
+output_threaded(sys) = sys._output_threaded
+
+celllist(sys::AbstractParticleSystem) = sys._cell_list
+celllist(sys::ParticleSystem2, s::Symbol) = celllist(sys, Val(s))
+celllist(sys, ::Val{:ref}) = sys._cell_list.ref_list
+celllist(sys, ::Val{:target}) = sys._cell_list.target_list
+
+n_real_particles(sys, s::Symbol) = n_real_particles(sys, Val(s)) 
+n_real_particles(sys, ::Val{:ref}) = sys._cell_list.ref_list.n_real_particles
+n_real_particles(sys, ::Val{:target}) = sys._cell_list.target_list.n_real_particles
+
+updated(sys, s::Symbol) = updated(sys, Val(s))
+updated(sys, ::Val{:x}) = sys.xpositions.updated[]
+updated(sys, ::Val{:y}) = sys.ypositions.updated[]
+
 #=
     unitcelltype(sys::AbstractParticleSystem)
 
 Returns the type of a unitcell from the `ParticleSystem` structure.
 
 =#
-unitcelltype(sys::AbstractParticleSystem) = unitcelltype(sys._box)
 
 ParticleSystem1{OutputName}(v::V, o::O, b::B, c::C, vo::AbstractVector{O}, a::A, p::Bool, vc::VC) where {OutputName, V, O, B, C, A, VC} =
     ParticleSystem1{OutputName, V, O, B, C, A, VC}(v, o, b, c, vo, a, p, vc)
@@ -22,25 +54,23 @@ import Base.show
 function Base.show(io::IO, mime::MIME"text/plain", sys::ParticleSystem1{OutputName}) where {OutputName}
     indent = get(io, :indent, 0)
     io_sub = IOContext(io, :indent => indent + 4)
-    N = size(sys.unitcell, 1)
-    println(io, "ParticleSystem1{$OutputName} of dimension $N, composed of:")
-    show(IOContext(io, :indent => indent + 4), mime, sys._box)
+    println(io, "ParticleSystem1{$OutputName} of dimension $(dim(sys)), composed of:")
+    show(IOContext(io, :indent => indent + 4), mime, box(sys))
     println(io)
-    show(io_sub, mime, sys._cell_list)
-    print(io, "\n    Parallelization auxiliary data set for $(nbatches(sys._cell_list, :build)) batch(es).")
-    return print(io, "\n    Type of output variable ($OutputName): $(typeof(sys.output))")
+    show(io_sub, mime, celllist(sys))
+    print(io, "\n    Parallelization auxiliary data set for $(nbatches(celllist(sys), :build)) batch(es).")
+    return print(io, "\n    Type of output variable ($OutputName): $(output_type(sys))")
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", sys::ParticleSystem2{OutputName}) where {OutputName}
     indent = get(io, :indent, 0)
     io_sub = IOContext(io, :indent => indent + 4)
-    N = size(sys.unitcell, 1)
-    println(io, "ParticleSystem2{$OutputName} of dimension $N, composed of:")
-    show(IOContext(io, :indent => indent + 4), mime, sys._box)
+    println(io, "ParticleSystem2{$OutputName} of dimension $(dim(sys)), composed of:")
+    show(IOContext(io, :indent => indent + 4), mime, box(sys))
     println(io)
-    show(io_sub, mime, sys._cell_list)
-    print(io, "\n    Parallelization auxiliary data set for $(nbatches(sys._cell_list, :build)) batch(es).")
-    return print(io, "\n    Type of output variable ($OutputName): $(typeof(sys.output))")
+    show(io_sub, mime, celllist(sys))
+    print(io, "\n    Parallelization auxiliary data set for $(nbatches(celllist(sys), :build)) batch(es).")
+    return print(io, "\n    Type of output variable ($OutputName): $(output_type(sys))")
 end
 
 #=
@@ -78,36 +108,43 @@ function reduce_output!(
     return output
 end
 
+#
+# Internal updaters
+#
+_update!(sys::AbstractParticleSystem, box::Box) = sys._box = box
+function _update!(sys::ParticleSystem1, ::Type{CellList}) 
+    n_particles_changed = length(sys.xpositions) != sys._cell_list.n_real_particles
+    UpdateCellList!(
+        sys.xpositions,
+        box(sys),
+        celllist(sys),
+        aux_threaded(sys);
+        parallel = sys.parallel,
+        validate_coordinates = sys.validate_coordinates,
+    )
+    if n_particles_changed
+        _old_nbatches = get_nbatches(sys)
+        sys._cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
+        _new_nbatches = get_nbatches(sys)
+        if _old_nbatches != _new_nbatches
+            sys._aux = _create_aux(box(sys), celllist(sys))
+            sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
+        end
+    end
+    sys.xpositions.updated[] = false
+    return sys
+end
+
 #=
     UpdateParticleSystem!
 
-Updates the cell lists for periodic systems.
+Updates the cell lists for ParticleSystem1
 
 =#
 function UpdateParticleSystem!(sys::ParticleSystem1)
-    if sys.xpositions.updated[]
-        if unitcelltype(sys) == NonPeriodicCell
-            sys._box = Box(limits(sys.xpositions), sys.cutoff)
-        end
-        n_particles_changed = length(sys.xpositions) != sys._cell_list.n_real_particles
-        sys._cell_list = UpdateCellList!(
-            sys.xpositions,
-            sys._box,
-            sys._cell_list,
-            sys._aux;
-            parallel = sys.parallel,
-            validate_coordinates = sys.validate_coordinates,
-        )
-        if n_particles_changed
-            _old_nbatches = get_nbatches(sys)
-            sys._cell_list = update_number_of_batches!(sys._cell_list; parallel = sys.parallel)
-            _new_nbatches = get_nbatches(sys)
-            if _old_nbatches != _new_nbatches
-                sys._aux = _create_aux(sys._box, sys._cell_list)
-                sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
-            end
-        end
-        sys.xpositions.updated[] = false
+    if updated(sys, :x)
+        unitcelltype(sys) == NonPeriodicCell && _update!(sys, Box(limits(sys.xpositions), cutoff(sys)))
+        _update!(sys, CellList)
     end
     return sys
 end
@@ -122,40 +159,52 @@ function _limits_fit_in_box(new_limits::Limits{N}, box::Box) where {N}
     return all(new_limits.origin .>= old_origin) && all(new_upper .<= old_upper)
 end
 
+function _update!(sys::ParticleSystem2, ::Type{CellList})
+    n_particles_changed = 
+        (length(sys.xpositions) != n_real_particles(sys, :ref)) ||
+        (length(sys.ypositions) != n_real_particles(sys, :target))
+    sys._cell_list = UpdateCellList!(
+        sys.xpositions,
+        sys.ypositions,
+        box(sys),
+        celllist(sys),
+        aux_threaded(sys);
+        parallel = sys.parallel,
+        validate_coordinates = sys.validate_coordinates,
+    )
+    if n_particles_changed
+        _old_nbatches = get_nbatches(sys)
+        sys._cell_list = update_number_of_batches!(celllist(sys); parallel = sys.parallel)
+        _new_nbatches = get_nbatches(sys)
+        if _old_nbatches != _new_nbatches
+            sys._aux = _create_aux(box(sys), celllist(sys))
+            sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
+        end
+    end
+    sys.xpositions.updated[] = false
+    sys.ypositions.updated[] = false
+    return sys
+end
+
+#=
+    UpdateParticleSystem!
+
+Updates the cell lists for ParticleSystem2
+
+=#
 function UpdateParticleSystem!(sys::ParticleSystem2)
-    if sys.xpositions.updated[] || sys.ypositions.updated[]
+    if updated(sys, :x) || updated(sys, :y) 
         if unitcelltype(sys) == NonPeriodicCell
             new_limits = limits(sys.xpositions, sys.ypositions)
-            if !_limits_fit_in_box(new_limits, sys._box)
-                sys._box = Box(new_limits, sys._box.cutoff)
+            if !_limits_fit_in_box(new_limits, box(sys))
+                _update!(sys, Box(new_limits, cutoff(sys)))
                 # Both cell lists must be rebuilt when the box changes,
                 # because the origin and sides changed.
                 sys.xpositions.updated[] = true
                 sys.ypositions.updated[] = true
             end
         end
-        n_particles_changed = (length(sys.xpositions) != sys._cell_list.ref_list.n_real_particles) ||
-            (length(sys.ypositions) != sys._cell_list.target_list.n_real_particles)
-        sys._cell_list = UpdateCellList!(
-            sys.xpositions,
-            sys.ypositions,
-            sys._box,
-            sys._cell_list,
-            sys._aux;
-            parallel = sys.parallel,
-            validate_coordinates = sys.validate_coordinates,
-        )
-        if n_particles_changed
-            _old_nbatches = get_nbatches(sys)
-            sys._cell_list = update_number_of_batches!(sys._cell_list; parallel = sys.parallel)
-            _new_nbatches = get_nbatches(sys)
-            if _old_nbatches != _new_nbatches
-                sys._aux = _create_aux(sys._box, sys._cell_list)
-                sys._output_threaded = [copy_output(sys.output) for _ in 1:_new_nbatches[2]]
-            end
-        end
-        sys.xpositions.updated[] = false
-        sys.ypositions.updated[] = false
+        _update!(sys, CellList)
     end
     return sys
 end
@@ -168,5 +217,5 @@ Returns the number of batches for parallel computations of cell list constructio
 and function mapping.
 
 """
-get_nbatches(sys::ParticleSystem1) = nbatches(sys._cell_list)
-get_nbatches(sys::ParticleSystem2) = nbatches(sys._cell_list.ref_list)
+get_nbatches(sys::ParticleSystem1) = nbatches(celllist(sys))
+get_nbatches(sys::ParticleSystem2) = nbatches(celllist(sys, :ref))

--- a/src/internals/neighborlist.jl
+++ b/src/internals/neighborlist.jl
@@ -58,7 +58,7 @@ end
 # shrink=false ensures this is a no-op when capacity is already sufficient,
 # preventing spurious allocations on repeated calls.
 function _sizehint_neighbor_lists!(sys::AbstractParticleSystem)
-    n_pairs = _estimated_n_pairs(sys._box, sys._cell_list)
+    n_pairs = _estimated_n_pairs(box(sys), celllist(sys))
     resize_output!(sys, n_pairs)
     return nothing
 end

--- a/src/internals/precompile.jl
+++ b/src/internals/precompile.jl
@@ -3,7 +3,7 @@ PrecompileTools.@setup_workload begin
     # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
     # precompile file and potentially make loading faster.
     import LinearAlgebra
-    cutoff = 0.05
+    r = 0.05
     x3d = rand(3, 3)
     x3d[:, 3] .= x3d[:, 2] .+ 1.0e-5
     y3d = copy(x3d)
@@ -14,25 +14,25 @@ PrecompileTools.@setup_workload begin
     u2d = [1.0 0.0; 0.0 1.0]
     f(pair, out) = out += pair.d2
     PrecompileTools.@compile_workload begin
-        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=cutoff, unitcell=u3d)
-        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=cutoff, unitcell=LinearAlgebra.diag(u3d))
-        neighborlist(xpositions=x3d, cutoff=cutoff, unitcell=u3d)
-        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=cutoff)
-        neighborlist(xpositions=x3d, cutoff=cutoff)
-        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=cutoff, unitcell=u2d)
-        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=cutoff, unitcell=LinearAlgebra.diag(u2d))
-        neighborlist(xpositions=x2d, cutoff=cutoff)
-        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=cutoff)
-        neighborlist(xpositions=x2d, cutoff=cutoff, unitcell=u2d)
+        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=r, unitcell=u3d)
+        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=r, unitcell=LinearAlgebra.diag(u3d))
+        neighborlist(xpositions=x3d, cutoff=r, unitcell=u3d)
+        neighborlist(xpositions=x3d, ypositions=y3d, cutoff=r)
+        neighborlist(xpositions=x3d, cutoff=r)
+        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=r, unitcell=u2d)
+        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=r, unitcell=LinearAlgebra.diag(u2d))
+        neighborlist(xpositions=x2d, cutoff=r)
+        neighborlist(xpositions=x2d, ypositions=y2d, cutoff=r)
+        neighborlist(xpositions=x2d, cutoff=r, unitcell=u2d)
         # 3D
-        sys = ParticleSystem(positions = x3d, unitcell = u3d, cutoff = cutoff, output = 0.0)
+        sys = ParticleSystem(positions=x3d, unitcell=u3d, cutoff=r, output=0.0)
         pairwise!(f, sys)
-        sys = ParticleSystem(xpositions = x3d, ypositions = y3d, unitcell = u3d, cutoff = cutoff, output = 0.0)
+        sys = ParticleSystem(xpositions=x3d, ypositions=y3d, unitcell=u3d, cutoff=r, output=0.0)
         pairwise!(f, sys)
         # 2D
-        sys = ParticleSystem(positions = x2d, unitcell = u2d, cutoff = cutoff, output = 0.0)
+        sys = ParticleSystem(positions=x2d, unitcell=u2d, cutoff=r, output=0.0)
         pairwise!(f, sys)
-        sys = ParticleSystem(xpositions = x2d, ypositions = y2d, unitcell = u2d, cutoff = cutoff, output = 0.0)
+        sys = ParticleSystem(xpositions=x2d, ypositions=y2d, unitcell=u2d, cutoff=r, output=0.0)
         pairwise!(f, sys)
     end
 end

--- a/test/API/BasicForParticleSystem.jl
+++ b/test/API/BasicForParticleSystem.jl
@@ -28,8 +28,12 @@
     @test pairwise!((pair, u) -> potential(pair.i, pair.j, pair.d2, u, mass), system) ≈ naive
     update!(system; parallel=true)
     @test pairwise!((pair, u) -> potential(pair.i, pair.j, pair.d2, u, mass), system) ≈ naive
+    
     # Test fetching by output name
     @test system.gravitational_potential ≈ naive
+
+    # Test fetching coordinates x-coordinates with alias
+    @test system.positions === system.xpositions
 
     # Same but for non-periodic systems
     system = ParticleSystem(

--- a/test/API/BasicForParticleSystem.jl
+++ b/test/API/BasicForParticleSystem.jl
@@ -154,9 +154,9 @@
 
     # property names and output name
     sys = ParticleSystem(xpositions = rand(3,10), cutoff=0.1, output=0.0)
-    @test propertynames(sys) == (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, :default_output_name)
+    @test propertynames(sys) == (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, :private, :default_output_name)
     sys = ParticleSystem(xpositions = rand(3,10), cutoff=0.1, output=0.0, output_name=:energy)
-    @test propertynames(sys) == (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, :energy)
+    @test propertynames(sys) == (:xpositions, :ypositions, :unitcell, :cutoff, :positions, :output, :parallel, :private, :energy)
 
     # NeighborPair interface
     p = NeighborPair(1, 2, SVector(1.0, 1.0), SVector(1.0, 3.0), 4.0)

--- a/test/API/BasicForParticleSystem.jl
+++ b/test/API/BasicForParticleSystem.jl
@@ -35,6 +35,9 @@
     # Test fetching coordinates x-coordinates with alias
     @test system.positions === system.xpositions
 
+    # Test internal getter function - not currently used, but available for symmetry. 
+    @test CellListMap.celllist(system, :target) === system.private.cell_list.target_list
+
     # Same but for non-periodic systems
     system = ParticleSystem(
         xpositions = x,

--- a/test/internals/NonPeriodicCells.jl
+++ b/test/internals/NonPeriodicCells.jl
@@ -9,13 +9,13 @@
     # These show methods are now internal and will be probably removed.
 
     sys = ParticleSystem(positions=x, cutoff=0.1, output=0.0, nbatches=(4,4))
-    @test parse_show(sys._aux; repl = Dict("CellListMap." => "")) ≈ """ 
+    @test parse_show(sys.private.aux; repl = Dict("CellListMap." => "")) ≈ """ 
         CellListMap.AuxNonPeriodic{3, Float64}
         Auxiliary arrays for nbatches = 4
     """
 
     sys2 = ParticleSystem(xpositions=x, ypositions=y, cutoff=0.1, output=0.0, nbatches=(4,4))
-    @test parse_show(sys2._aux; repl = Dict("CellListMap." => "")) ≈ """ 
+    @test parse_show(sys2.private.aux; repl = Dict("CellListMap." => "")) ≈ """ 
         CellListMap.AuxNonPeriodicPair{3, Float64}
         Auxiliary arrays for nbatches = (4, 4)
     """

--- a/test/modules/Testing.jl
+++ b/test/modules/Testing.jl
@@ -60,9 +60,9 @@ Returns `x`, `y`, `sides` and `cutoff`.
     end
 
     map_naive!(f, sys::ParticleSystem1) =
-        map_naive!(f, reset_output!(sys.output), sys.xpositions.x, sys._box)
+        map_naive!(f, reset_output!(sys.output), sys.xpositions.x, sys.private.box)
     map_naive!(f, sys::ParticleSystem2) =
-        map_naive!(f, reset_output!(sys.output), sys.xpositions.x, sys.ypositions.x, sys._box)
+        map_naive!(f, reset_output!(sys.output), sys.xpositions.x, sys.ypositions.x, sys.private.box)
 
     #=
     map_naive!(f::Function, output, x::AbstractVector, box::Box)


### PR DESCRIPTION

Make all ParticleSystem internal variables internal to the new "private" field, and accessed through getters.