### PR TITLE
Remove OrthorhombicCell inverse rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CellListMap.jl Changelog
 
 Version 0.10.3-DEV
 --------------
+- ![ENHANCEMENT][badge-enhancement] Skip `inv_rotation` for `OrthorhombicCell`s. 
 - ![INFO][badge-info] Clarifty the meaning of `NeighborPair` fields, specifically concerning the minimum-image consideration.
 - ![INFO][badge-info] Document the possibility of modifying individual positions with `setindex!` and `SVector`s. 
 

--- a/src/internals/self.jl
+++ b/src/internals/self.jl
@@ -142,9 +142,6 @@ end
 # upper triangle only in the case of the Orthorhombic cell
 function _current_cell_interactions!(box::Box{OrthorhombicCell}, f::F, cell, output) where {F <: Function}
     (; cutoff_sqr, inv_rotation) = box
-    # For OrthorhombicCell the cell is axis-aligned, so `inv_rotation` is the identity.
-    # The minimum-image-adjusted coordinates are therefore the stored coordinates, and the
-    # per-pair matrix-vector products `inv_rotation * x` can be skipped entirely.
     for i in 1:(cell.n_particles - 1)
         @inbounds pᵢ = cell.particles[i]
         xpᵢ = pᵢ.coordinates
@@ -154,6 +151,7 @@ function _current_cell_interactions!(box::Box{OrthorhombicCell}, f::F, cell, out
             xpⱼ = pⱼ.coordinates
             d2 = sum(abs2, xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
+                # `inv_rotation` is the identity here
                 pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ, xpⱼ, d2)
                 output = f(pair, output)
             end

--- a/src/internals/self.jl
+++ b/src/internals/self.jl
@@ -142,18 +142,19 @@ end
 # upper triangle only in the case of the Orthorhombic cell
 function _current_cell_interactions!(box::Box{OrthorhombicCell}, f::F, cell, output) where {F <: Function}
     (; cutoff_sqr, inv_rotation) = box
-    # loop over list of non-repeated particles of cell ic.
+    # For OrthorhombicCell the cell is axis-aligned, so `inv_rotation` is the identity.
+    # The minimum-image-adjusted coordinates are therefore the stored coordinates, and the
+    # per-pair matrix-vector products `inv_rotation * x` can be skipped entirely.
     for i in 1:(cell.n_particles - 1)
         @inbounds pᵢ = cell.particles[i]
         xpᵢ = pᵢ.coordinates
-        xpᵢ_rot = inv_rotation * xpᵢ
         for j in (i + 1):cell.n_particles
             @inbounds pⱼ = cell.particles[j]
             (pᵢ.real | pⱼ.real) || continue
             xpⱼ = pⱼ.coordinates
             d2 = sum(abs2, xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
-                pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ_rot, inv_rotation * xpⱼ, d2)
+                pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ, xpⱼ, d2)
                 output = f(pair, output)
             end
         end

--- a/src/internals/vicinal_cells.jl
+++ b/src/internals/vicinal_cells.jl
@@ -20,9 +20,6 @@ end
 #
 function _vinicial_cells!(f::F, box::Box{OrthorhombicCell}, cellᵢ, pp, Δc, output, ::Val{Skip}) where {F <: Function, Skip}
     (; cutoff, cutoff_sqr, inv_rotation) = box
-    # For OrthorhombicCell `inv_rotation` is the identity (axis-aligned cell), so the
-    # minimum-image-adjusted coordinates are the stored coordinates and the per-pair
-    # `inv_rotation * x` products can be skipped.
     for i in 1:cellᵢ.n_particles
         @inbounds pᵢ = cellᵢ.particles[i]
         # project particle in vector connecting cell centers
@@ -37,6 +34,7 @@ function _vinicial_cells!(f::F, box::Box{OrthorhombicCell}, cellᵢ, pp, Δc, ou
             xpⱼ = pⱼ.coordinates
             d2 = sum(abs2, xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
+                # `inv_rotation` is the identity here
                 pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ, xpⱼ, d2)
                 output = f(pair, output)
             end

--- a/src/internals/vicinal_cells.jl
+++ b/src/internals/vicinal_cells.jl
@@ -20,12 +20,13 @@ end
 #
 function _vinicial_cells!(f::F, box::Box{OrthorhombicCell}, cellᵢ, pp, Δc, output, ::Val{Skip}) where {F <: Function, Skip}
     (; cutoff, cutoff_sqr, inv_rotation) = box
-    # Loop over particles of cell icell
+    # For OrthorhombicCell `inv_rotation` is the identity (axis-aligned cell), so the
+    # minimum-image-adjusted coordinates are the stored coordinates and the per-pair
+    # `inv_rotation * x` products can be skipped.
     for i in 1:cellᵢ.n_particles
         @inbounds pᵢ = cellᵢ.particles[i]
         # project particle in vector connecting cell centers
         xpᵢ = pᵢ.coordinates
-        xpᵢ_rot = inv_rotation * xpᵢ
         xproj = dot(xpᵢ - cellᵢ.center, Δc)
         # Partition pp array according to the current projections
         n = partition!(el -> abs(el.xproj - xproj) <= cutoff, pp)
@@ -36,7 +37,7 @@ function _vinicial_cells!(f::F, box::Box{OrthorhombicCell}, cellᵢ, pp, Δc, ou
             xpⱼ = pⱼ.coordinates
             d2 = sum(abs2, xpᵢ - xpⱼ)
             if d2 <= cutoff_sqr
-                pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ_rot, inv_rotation * xpⱼ, d2)
+                pair = NeighborPair(pᵢ.index, pⱼ.index, xpᵢ, xpⱼ, d2)
                 output = f(pair, output)
             end
         end


### PR DESCRIPTION
I was optimising Molly with AI tools and CellListMap seems pretty well-optimised, so thanks for that.

The following change was suggested and seems reasonable to me, it seemed to give a marginal speedup though the benchmark was noisy on my machine.